### PR TITLE
TimeOnly/GetDayProgress fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Changes
 
+Implemented the following fixes to the `TimeOnly` class:
+
+- Fixed a mistake where the numerator and denominator of the `GetDayProgress` method were switched.
+- Added missing unit tests for the `GetDayProgress` method.
+
 Added the following properties to the `OnTimeChangedEventArgs` class:
 
 - `PreviousTime`: A `TimeOnly` representing the time at the frame before the event was invoked.

--- a/Runtime/TimeOnly/TimeOnly.cs
+++ b/Runtime/TimeOnly/TimeOnly.cs
@@ -178,7 +178,7 @@ namespace GameTime
         /// Computes the proportion of the day completed relative to midnight.
         /// </summary>
         /// <returns>A float between [0,1) that represents the proportion of the day completed.</returns>
-        public float GetDayProgress() => (float)NUM_MILLISECONDS_PER_DAY / BackingTime;
+        public float GetDayProgress() => (float)BackingTime / NUM_MILLISECONDS_PER_DAY;
         
         /// <summary>
         /// Determines if it is morning.

--- a/Tests/Runtime/TimeOnlyTests.cs
+++ b/Tests/Runtime/TimeOnlyTests.cs
@@ -215,6 +215,21 @@ namespace Tests.Runtime
         }
 
         [Test]
+        public void TestGetDayProgress()
+        {
+            float tolerance = 0.00001f;
+            
+            Assert.That(Time_0_00.GetDayProgress(), Is.EqualTo(0f));
+            Assert.That(Time_1_00.GetDayProgress(), Is.EqualTo(0.04167f).Within(tolerance));
+            Assert.That(Time_3_30.GetDayProgress(), Is.EqualTo(0.14583f).Within(tolerance));
+            Assert.That(Time_7_00.GetDayProgress(), Is.EqualTo(0.29167f).Within(tolerance));
+            Assert.That(Time_12_00.GetDayProgress(), Is.EqualTo(0.5f).Within(tolerance));
+            Assert.That(Time_16_30.GetDayProgress(), Is.EqualTo(0.6875f).Within(tolerance));
+            Assert.That(Time_19_00.GetDayProgress(), Is.EqualTo(0.79167f).Within(tolerance));
+            Assert.That(Time_23_30.GetDayProgress(), Is.EqualTo(0.97917f).Within(tolerance));
+        }
+
+        [Test]
         public void TestStringFormatting()
         {
             Assert.That($"{Time_0_00:HH:mm:ss:fff}", Is.EqualTo("00:00:00:000"));


### PR DESCRIPTION
Implemented the following fixes to the `TimeOnly` class:

- Fixed a mistake where the numerator and denominator of the `GetDayProgress` method were switched.
- Added missing unit tests for the `GetDayProgress` method.