### PR TITLE
Added static generation methods for TimeOnly and Duration structs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## [1.0.2] - 2025-10-11
+
+Implemented the following changes to the `TimeOnly` struct:
+
+- Added static methods for generating struct from a single type of non-millisecond unit.
+  - `TimeOnly.FromHours` creates a new `TimeOnly` where the time is equal to the specified number
+  of hours elapsed since midnight.
+  - `TimeOnly.FromMinutes` creates a new `TimeOnly` where the time is equal to the specified number
+    of minutes elapsed since midnight.
+  - `TimeOnly.FromSeconds` creates a new `TimeOnly` where the time is equal to the specified number
+    of seconds elapsed since midnight.
+
+Implemented the following changes to the `Duration` struct:
+
+- Added static methods for generating struct from a single type of non-millisecond unit.
+    - `Duration.FromDays` creates a new `Duration` where the timespan is equal to the specified number
+      of days elapsed.
+    - `Duration.FromHours` creates a new `Duration` where the timespan is equal to the specified number
+      of hours elapsed.
+    - `Duration.FromHours` creates a new `Duration` where the timespan is equal to the specified number
+      of minutes elapsed.
+    - `Duration.FromHours` creates a new `Duration` where the timespan is equal to the specified number
+      of seconds elapsed.
+
 ## [1.0.1] - 2025-10-08
 
 ### Changes

--- a/Runtime/Clock/Clock.cs
+++ b/Runtime/Clock/Clock.cs
@@ -116,7 +116,7 @@ namespace GameTime.Clock
         /// equal to two in-game hours.
         /// </param>
         public void AdvanceTime(float scalar = 1)
-            => Time += scalar * new Duration(TimeConversions.SecondsToMilliseconds(UnityEngine.Time.deltaTime));
+            => Time += scalar * Duration.FromSeconds(UnityEngine.Time.deltaTime);
 
         /// <summary>
         /// Determines if the <c>Time</c> property of the clock is equal to another time at the

--- a/Runtime/Duration/StaticMethods.cs
+++ b/Runtime/Duration/StaticMethods.cs
@@ -1,0 +1,46 @@
+using static GameTime.TimeConversions;
+
+namespace GameTime
+{
+    
+    public partial struct Duration
+    {
+        
+        /// <summary>
+        /// Creates a new <c>Duration</c> where the timespan is equal to the specified number of days.
+        /// </summary>
+        /// <param name="days">The number of days elapsed.</param>
+        /// <returns>A new <c>Duration</c>.</returns>
+        public static Duration FromDays(int days) => new(DaysToMilliseconds(days));
+        
+        /// <summary>
+        /// Creates a new <c>Duration</c> where the timespan is equal to the specified number of hours.
+        /// </summary>
+        /// <param name="hours">The number of hours elapsed.</param>
+        /// <returns>A new <c>Duration</c>.</returns>
+        public static Duration FromHours(int hours) => new(HoursToMilliseconds(hours));
+        
+        /// <summary>
+        /// Creates a new <c>Duration</c> where the timespan is equal to the specified number of minutes.
+        /// </summary>
+        /// <param name="minutes">The number of minutes elapsed.</param>
+        /// <returns>A new <c>Duration</c>.</returns>
+        public static Duration FromMinutes(int minutes) => new(MinutesToMilliseconds(minutes));
+        
+        /// <summary>
+        /// Creates a new <c>Duration</c> where the timespan is equal to the specified number of seconds.
+        /// </summary>
+        /// <param name="seconds">The number of seconds elapsed.</param>
+        /// <returns>A new <c>Duration</c>.</returns>
+        public static Duration FromSeconds(int seconds) => new(SecondsToMilliseconds(seconds));
+        
+        /// <summary>
+        /// Creates a new <c>Duration</c> where the timespan is equal to the specified number of seconds.
+        /// </summary>
+        /// <param name="seconds">The number of seconds elapsed.</param>
+        /// <returns>A new <c>Duration</c>.</returns>
+        public static Duration FromSeconds(float seconds) => FromSeconds((int)seconds);
+        
+    }
+    
+}

--- a/Runtime/Duration/StaticMethods.cs.meta
+++ b/Runtime/Duration/StaticMethods.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8b707bc9555b4b29b9ba6ad065c56cfd
+timeCreated: 1760157591

--- a/Runtime/TimeOnly/StaticMethods.cs
+++ b/Runtime/TimeOnly/StaticMethods.cs
@@ -1,0 +1,7 @@
+namespace GameTime
+{
+    public class StaticMethods
+    {
+        
+    }
+}

--- a/Runtime/TimeOnly/StaticMethods.cs
+++ b/Runtime/TimeOnly/StaticMethods.cs
@@ -1,7 +1,32 @@
+using static GameTime.TimeConversions;
+
 namespace GameTime
 {
-    public class StaticMethods
+    
+    public partial struct TimeOnly
     {
         
+        /// <summary>
+        /// Creates a new <c>TimeOnly</c> from the specified hours.
+        /// </summary>
+        /// <param name="hours">The number of hours elapsed since midnight.</param>
+        /// <returns>A new <c>TimeOnly</c>.</returns>
+        public static TimeOnly FromHours(int hours) => new(hours, 0);
+
+        /// <summary>
+        /// Creates a new <c>TimeOnly</c> from the specified minutes.
+        /// </summary>
+        /// <param name="minutes">The number of minutes elapsed since midnight.</param>
+        /// <returns>A new <c>TimeOnly</c>.</returns>
+        public static TimeOnly FromMinutes(int minutes) => new(0, minutes);
+        
+        /// <summary>
+        /// Creates a new <c>TimeOnly</c> from the specified seconds.
+        /// </summary>
+        /// <param name="seconds">The number of seconds elapsed since midnight.</param>
+        /// <returns>A new <c>TimeOnly</c>.</returns>
+        public static TimeOnly FromSeconds(int seconds) => new(SecondsToMilliseconds(seconds));
+        
     }
+    
 }

--- a/Runtime/TimeOnly/StaticMethods.cs.meta
+++ b/Runtime/TimeOnly/StaticMethods.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7eb51825da6740c3985d12de380e46e0
+timeCreated: 1760157440

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "com.gitamend.gametime",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "displayName": "Game Time",
   "description": "Contains time structs similar to the dotnet TimeOnly struct which is not available in Unity. Use to manage in-game time.",
   "author": {
     "name": "CalamityBox",
-    "url": ""
+    "url": "https://github.com/CalamityBox"
   }
 }


### PR DESCRIPTION
Implemented the following changes to the `TimeOnly` struct:

- Added static methods for generating struct from a single type of non-millisecond unit.
  - `TimeOnly.FromHours` creates a new `TimeOnly` where the time is equal to the specified number
  of hours elapsed since midnight.
  - `TimeOnly.FromMinutes` creates a new `TimeOnly` where the time is equal to the specified number
    of minutes elapsed since midnight.
  - `TimeOnly.FromSeconds` creates a new `TimeOnly` where the time is equal to the specified number
    of seconds elapsed since midnight.

Implemented the following changes to the `Duration` struct:

- Added static methods for generating struct from a single type of non-millisecond unit.
    - `Duration.FromDays` creates a new `Duration` where the timespan is equal to the specified number
      of days elapsed.
    - `Duration.FromHours` creates a new `Duration` where the timespan is equal to the specified number
      of hours elapsed.
    - `Duration.FromHours` creates a new `Duration` where the timespan is equal to the specified number
      of minutes elapsed.
    - `Duration.FromHours` creates a new `Duration` where the timespan is equal to the specified number
      of seconds elapsed.