### PR TITLE
Clock rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ comparison methods, `IsHourEqual`, `IsMinuteEqual`, `IsSecondEqual`.
 the overriden `IsEqual` method.
 - Reworked class constructors to assign their own `Time` component changed events.
 
+Implemented the following changes to the `Duration` struct:
+
+- Fixed a casting error in the `FromSeconds` float method.
+
 ## [1.0.2] - 2025-10-11
 
 Implemented the following changes to the `TimeOnly` struct:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [1.1.0] - 2025-10-11
+
+Implemented the following changes to the `Clock` class:
+
+- Reworked the `OnTimeChanged` event to correspond to **any** change in the clock's `Time` property.
+- Moved previous behavior of `OnTimeChanged` into a new event, `OnClockChanged`.
+- Updated the `IsEqual` methods of the inheriting clock classes to utilize the built-in `TimeOnly`
+comparison methods, `IsHourEqual`, `IsMinuteEqual`, `IsSecondEqual`.
+- Removed the `HandleSetterEvents` method and implementations.
+- Reworked `BaseClock` to handle the `OnClockChanged` event for all inherting clocks by utilizing
+the overriden `IsEqual` method.
+- Reworked class constructors to assign their own `Time` component changed events.
+
 ## [1.0.2] - 2025-10-11
 
 Implemented the following changes to the `TimeOnly` struct:

--- a/Runtime/Duration/StaticMethods.cs
+++ b/Runtime/Duration/StaticMethods.cs
@@ -39,7 +39,7 @@ namespace GameTime
         /// </summary>
         /// <param name="seconds">The number of seconds elapsed.</param>
         /// <returns>A new <c>Duration</c>.</returns>
-        public static Duration FromSeconds(float seconds) => FromSeconds((int)seconds);
+        public static Duration FromSeconds(float seconds) => new(SecondsToMilliseconds(seconds));
         
     }
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.gitamend.gametime",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "displayName": "Game Time",
   "description": "Contains time structs similar to the dotnet TimeOnly struct which is not available in Unity. Use to manage in-game time.",
   "author": {


### PR DESCRIPTION
Implemented the following changes to the `Clock` class:

- Reworked the `OnTimeChanged` event to correspond to **any** change in the clock's `Time` property.
- Moved previous behavior of `OnTimeChanged` into a new event, `OnClockChanged`.
- Updated the `IsEqual` methods of the inheriting clock classes to utilize the built-in `TimeOnly`
comparison methods, `IsHourEqual`, `IsMinuteEqual`, `IsSecondEqual`.
- Removed the `HandleSetterEvents` method and implementations.
- Reworked `BaseClock` to handle the `OnClockChanged` event for all inherting clocks by utilizing
the overriden `IsEqual` method.
- Reworked class constructors to assign their own `Time` component changed events.

Implemented the following changes to the `Duration` struct:

- Fixed a casting error in the `FromSeconds` float method.